### PR TITLE
Added support to set up a validate options for validate() in "form" type

### DIFF
--- a/src/dform.extensions.js
+++ b/src/dform.extensions.js
@@ -541,6 +541,8 @@
 						}
 					};
 				}
+				if (typeof (options.validate) == 'object')
+					$.extend(defaults, options.validate);
 				this.validate(defaults);
 			}
 		},
@@ -555,7 +557,8 @@
 		 */
 		"validate" : function(options, type)
 		{
-			this.rules("add", options);
+			if (type != "form")
+				this.rules("add", options);
 		}
 	});
 


### PR DESCRIPTION
Sometimes i need to setup validate options for validate() method (in dform: '[pre]' subscription for 'form')

Example: current version doesn't allow to me set up validate options for radiobuttons. I cannot use validate subscription for "radiobutton" (because it's "div" and there is exception of validate plugin)

I don't know other way only to do it through:
form.validate({rules: {radio_group: "required"}})
But current version of dform doesn't have a way to setup this options

Here a patch
Now we can to do it like:
{
 action: "/url/here/",
 method: "post",
 validate: {rules: {radio_group_name: "required"}},
 elements:
  [
   ....
  ]
}

My examples are works for this.
