### PR TITLE
Allow passing of "value" parameter in options of checkboxes and radiobuttons

### DIFF
--- a/src/dform.core.js
+++ b/src/dform.core.js
@@ -125,7 +125,7 @@
 					} else {
 						$.extend(boxoptions, content);
 					}
-					boxoptions["value"] = value;
+					boxoptions["value"] = typeof content["value"] !== 'undefined' ? content["value"]  : value;
 					self.dform('append', boxoptions);
 				});
 			}

--- a/src/dform.core.js
+++ b/src/dform.core.js
@@ -125,7 +125,7 @@
 					} else {
 						$.extend(boxoptions, content);
 					}
-					boxoptions["value"] = typeof content["value"] !== 'undefined' ? content["value"]  : value;
+					boxoptions["value"] = typeof (content["value"]) !== 'undefined' ? content["value"]  : value;
 					self.dform('append', boxoptions);
 				});
 			}


### PR DESCRIPTION
Added check to "options" subscriber to test for a value being passed to the checkboxes or radiobuttons type.

The idea is to allow the ability to pass the same value for multiple checkboxes like so:

```
html : {
    type : 'checkboxes',
    caption: 'My cool test',
    options : [
        {name: 'foo', value: true},
        {name: 'bar', value: true}
    ]
}
```
