### PR TITLE
Added support for input type color

### DIFF
--- a/src/dform.core.js
+++ b/src/dform.core.js
@@ -38,6 +38,7 @@
 		url : _element('<input type="url" />'),
 		tel : _element('<input type="tel" />'),
 		email : _element('<input type="email" />'),
+		color : _element('<input type="color" />'),
 		checkboxes : _element("<div>", ["name"]),
 		radiobuttons : _element("<div>", ["name"])
 	});


### PR DESCRIPTION
The input type 'color' is simply an input html tag, with the type set to color.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color
